### PR TITLE
Make sure compiler optimizations are disabled and

### DIFF
--- a/recipes-extended/xen/files/libxl-xenmgr-stuff.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-stuff.patch
@@ -438,7 +438,7 @@ Index: xen-4.6.1/tools/libxl/libxl_utils.c
  int libxl_domain_qualifier_to_domid(libxl_ctx *ctx, const char *name,
                                      uint32_t *domid)
  {
-@@ -1195,6 +1253,102 @@ int libxl_domid_valid_guest(uint32_t dom
+@@ -1195,6 +1253,96 @@ int libxl_domid_valid_guest(uint32_t dom
      return domid > 0 && domid < DOMID_FIRST_RESERVED;
  }
  
@@ -448,16 +448,13 @@ Index: xen-4.6.1/tools/libxl/libxl_utils.c
 +	char uuid[37];
 +	libxl_dominfo domain;
 +
-+	xs_transaction_t t = 0;
 +	libxl_domain_info(ctx, &domain, domid);
 +
 +	uuid_unparse(domain.uuid.uuid, uuid);
-+	t = xs_transaction_start(ctx->xsh);
 +	sprintf(path, "/state/%s/reboot", uuid);    
 +
-+	*state = xs_read(ctx->xsh, t, path, NULL);
++	*state = xs_read(ctx->xsh, XBT_NULL, path, NULL);
 +
-+	xs_transaction_end(ctx->xsh, t, 0);
 +	return 0;
 +}
 +
@@ -466,19 +463,16 @@ Index: xen-4.6.1/tools/libxl/libxl_utils.c
 +	char path[49];
 +	char uuid[37];
 +	libxl_dominfo domain;
-+	xs_transaction_t t = 0;
 +
 +	libxl_domain_info(ctx, &domain, domid);
 +	uuid_unparse(domain.uuid.uuid, uuid);
 +
-+	t = xs_transaction_start(ctx->xsh);
 +	sprintf(path, "/state/%s/reboot", uuid);
 +	if(reboot)
-+	   xs_write(ctx->xsh, t, path, "1", strlen("1"));
++	   xs_write(ctx->xsh, XBT_NULL, path, "1", strlen("1"));
 +	else
-+	   xs_rm(ctx->xsh, t, path); 
++	   xs_rm(ctx->xsh, XBT_NULL, path); 
 +
-+	xs_transaction_end(ctx->xsh, t, 0);
 +	return 0;
 +}
 +

--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -8,10 +8,23 @@ EXTRA_OEMAKE += "CROSS_SYS_ROOT=${STAGING_DIR_HOST} CROSS_COMPILE=${HOST_PREFIX}
 EXTRA_OEMAKE += "CONFIG_IOEMU=n"
 EXTRA_OEMAKE += "DESTDIR=${D}"
 
-TARGET_CC_ARCH += "${LDFLAGS}"
+#Make sure we disable all compiler optimizations to avoid a nasty segfault in the 
+#reboot case.
+BUILD_LDFLAGS += " -Wl,-O0 -O0"
+BUILDSDK_LDFLAGS += " -Wl,-O0 -O0"
+TARGET_LDFLAGS += " -Wl,-O0 -O0"
+BUILD_OPTIMIZATION = "-pipe"
+FULL_OPTIMIZATION = "-pipe ${DEBUG_FLAGS}"
 
+TARGET_CC_ARCH += "${LDFLAGS}"
 do_configure() {
         DESTDIR=${D} ./configure --prefix=${prefix}
+}
+
+do_configure_prepend() {
+	#remove optimizations in the config files
+	sed -i 's/-O2//g' ${WORKDIR}/xen-4.6.1/Config.mk
+	sed -i 's/-O2//g' ${WORKDIR}/xen-4.6.1/config/StdGNU.mk
 }
 
 do_compile() {


### PR DESCRIPTION
fix some errors with xsWrites when doing domain reboots.  Setting
the transaction to XBT_NULL ensures the writes go through to the xs.
We disable optimizaions because the compiler corrupts the stack
when doing domain reboots. The libxl_ctx \* points to invalid memory,
causing a segfault.

Signed-off-by: Chris Rogers rogersc@ainfosec.com
