### PR TITLE
Fix outstanding state update issues

### DIFF
--- a/recipes-extended/xen/files/libxl-crypto-key-dir.patch
+++ b/recipes-extended/xen/files/libxl-crypto-key-dir.patch
@@ -33,7 +33,7 @@ Index: xen-4.6.1/tools/libxl/libxl.c
 ===================================================================
 --- xen-4.6.1.orig/tools/libxl/libxl.c
 +++ xen-4.6.1/tools/libxl/libxl.c
-@@ -2563,7 +2563,7 @@ static void device_disk_add(libxl__egc *
+@@ -2561,7 +2561,7 @@ static void device_disk_add(libxl__egc *
              case LIBXL_DISK_BACKEND_TAP:
                  if (dev == NULL) {
                      dev = libxl__blktap_devpath(gc, disk->pdev_path,

--- a/recipes-extended/xen/files/libxl-domain-state.patch
+++ b/recipes-extended/xen/files/libxl-domain-state.patch
@@ -64,15 +64,6 @@ Index: xen-4.6.1/tools/libxl/libxl.c
      if (ret<0) {
          LIBXL__LOG_ERRNO(ctx, LIBXL__LOG_ERROR, "unpausing domain %d", domid);
          rc = ERROR_FAIL;
-@@ -1263,6 +1271,8 @@ static void domain_death_xswatch_callbac
-                 libxl__event_occurred(egc, ev);
- 
-                 evg->shutdown_reported = 1;
-+
-+                libxl_update_state(egc->gc.owner, got->domain, "shutdown");
-             }
-             evg = LIBXL_TAILQ_NEXT(evg, entry);
-         }
 Index: xen-4.6.1/tools/libxl/libxl_create.c
 ===================================================================
 --- xen-4.6.1.orig/tools/libxl/libxl_create.c
@@ -200,7 +191,11 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
 ===================================================================
 --- xen-4.6.1.orig/tools/libxl/xl_cmdimpl.c
 +++ xen-4.6.1/tools/libxl/xl_cmdimpl.c
-@@ -2439,6 +2439,7 @@ static int handle_domain_death(uint32_t
+@@ -2436,9 +2436,11 @@ static int handle_domain_death(uint32_t
+         break;
+     case LIBXL_SHUTDOWN_REASON_REBOOT:
+         action = d_config->on_reboot;
++        libxl_update_state(ctx, *r_domid, "rebooting");
          break;
      case LIBXL_SHUTDOWN_REASON_SUSPEND:
          LOG("Domain has suspended.");
@@ -208,7 +203,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
          return 0;
      case LIBXL_SHUTDOWN_REASON_CRASH:
          action = d_config->on_crash;
-@@ -2899,6 +2900,8 @@ start:
+@@ -2899,6 +2901,8 @@ start:
          restore_fd_to_close = -1;
      }
  
@@ -217,7 +212,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
      if (!paused)
          libxl_domain_unpause(ctx, domid);
  
-@@ -2992,6 +2995,7 @@ start:
+@@ -2992,6 +2996,7 @@ start:
                   * re-creation fails sometimes.
                   */
                  LOG("Done. Rebooting now");
@@ -225,15 +220,15 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
                  sleep(2);
                  goto start;
  
-@@ -3009,6 +3013,7 @@ start:
-             LOG("Domain %d has been destroyed.", domid);
-             libxl_event_free(ctx, event);
-             ret = 0;
-+            libxl_update_state(ctx, domid, "shutdown");
-             goto out;
+@@ -2999,6 +3004,7 @@ start:
+                 LOG("Done. Exiting now");
+                 libxl_event_free(ctx, event);
+                 ret = 0;
++                libxl_update_state_direct(ctx, d_config.c_info.uuid, "shutdown");
+                 goto out;
  
-         case LIBXL_EVENT_TYPE_DISK_EJECT:
-@@ -3030,6 +3035,7 @@ error_out:
+             default:
+@@ -3030,6 +3036,7 @@ error_out:
      release_lock();
      if (libxl_domid_valid_guest(domid)) {
          libxl_domain_destroy(ctx, domid, 0);
@@ -241,7 +236,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
          domid = INVALID_DOMID;
      }
  
-@@ -3663,6 +3669,7 @@ static void destroy_domain(uint32_t domi
+@@ -3663,6 +3670,7 @@ static void destroy_domain(uint32_t domi
      }
      rc = libxl_domain_destroy(ctx, domid, 0);
      if (rc) { fprintf(stderr,"destroy failed (rc=%d)\n",rc); exit(-1); }
@@ -249,7 +244,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
  }
  
  static void wait_for_domain_deaths(libxl_evgen_domain_death **deathws, int nr)
-@@ -3705,6 +3712,7 @@ static void shutdown_domain(uint32_t dom
+@@ -3705,6 +3713,7 @@ static void shutdown_domain(uint32_t dom
      int rc;
  
      fprintf(stderr, "Shutting down domain %d\n", domid);
@@ -257,7 +252,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
      rc=libxl_domain_shutdown(ctx, domid);
      if (rc == ERROR_NOPARAVIRT) {
          if (fallback_trigger) {
-@@ -3737,6 +3745,7 @@ static void reboot_domain(uint32_t domid
+@@ -3737,6 +3746,7 @@ static void reboot_domain(uint32_t domid
      int rc;
  
      fprintf(stderr, "Rebooting domain %d\n", domid);

--- a/recipes-extended/xen/files/libxl-fix-reboot.patch
+++ b/recipes-extended/xen/files/libxl-fix-reboot.patch
@@ -92,7 +92,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
 ===================================================================
 --- xen-4.6.1.orig/tools/libxl/xl_cmdimpl.c
 +++ xen-4.6.1/tools/libxl/xl_cmdimpl.c
-@@ -2437,11 +2437,21 @@ static int handle_domain_death(uint32_t
+@@ -2437,11 +2437,24 @@ static int handle_domain_death(uint32_t
  
  {
      int restart = 0;
@@ -109,12 +109,15 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
 +            {
 +                LOG("Setting domain action to reboot");
 +                action = d_config->on_reboot;       
++                libxl_update_state(ctx, *r_domid, "rebooting");
 +            }
++        } else {
++            libxl_update_state(ctx, *r_domid, "shutdowning");
 +        }
          break;
      case LIBXL_SHUTDOWN_REASON_REBOOT:
          action = d_config->on_reboot;
-@@ -2495,6 +2505,7 @@ static int handle_domain_death(uint32_t
+@@ -2496,6 +2509,7 @@ static int handle_domain_death(uint32_t
      case LIBXL_ACTION_ON_SHUTDOWN_RESTART:
          reload_domain_config(*r_domid, d_config);
          restart = 1;
@@ -122,7 +125,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
          /* fall-through */
      case LIBXL_ACTION_ON_SHUTDOWN_DESTROY:
          LOG("Domain %d needs to be cleaned up: destroying the domain",
-@@ -2897,6 +2908,7 @@ start:
+@@ -2898,6 +2912,7 @@ start:
          ret = libxl_domain_create_new(ctx, &d_config, &domid,
                                        0, autoconnect_console_how);
      }
@@ -130,7 +133,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
      if ( ret )
          goto error_out;
  
-@@ -3788,12 +3800,13 @@ static void reboot_domain(uint32_t domid
+@@ -3789,12 +3804,13 @@ static void reboot_domain(uint32_t domid
  
      fprintf(stderr, "Rebooting domain %d\n", domid);
      libxl_update_state(ctx, domid, "rebooting");

--- a/recipes-extended/xen/files/libxl-fixup-cmdline-ops.patch
+++ b/recipes-extended/xen/files/libxl-fixup-cmdline-ops.patch
@@ -194,7 +194,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
 ===================================================================
 --- xen-4.6.1.orig/tools/libxl/xl_cmdimpl.c
 +++ xen-4.6.1/tools/libxl/xl_cmdimpl.c
-@@ -3704,6 +3704,39 @@ static void wait_for_domain_deaths(libxl
+@@ -3705,6 +3705,39 @@ static void wait_for_domain_deaths(libxl
      }
  }
  
@@ -234,7 +234,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
  static void shutdown_domain(uint32_t domid,
                              libxl_evgen_domain_death **deathw,
                              libxl_ev_user for_user,
-@@ -4790,6 +4823,43 @@ int main_destroy(int argc, char **argv)
+@@ -4791,6 +4824,43 @@ int main_destroy(int argc, char **argv)
      return 0;
  }
  
@@ -278,7 +278,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
  static int main_shutdown_or_reboot(int do_reboot, int argc, char **argv)
  {
      const char *what = do_reboot ? "reboot" : "shutdown";
-@@ -6329,6 +6399,51 @@ int main_domname(int argc, char **argv)
+@@ -6330,6 +6400,51 @@ int main_domname(int argc, char **argv)
      return 0;
  }
  
@@ -330,7 +330,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
  int main_rename(int argc, char **argv)
  {
      uint32_t domid;
-@@ -6379,7 +6494,15 @@ int main_trigger(int argc, char **argv)
+@@ -6380,7 +6495,15 @@ int main_trigger(int argc, char **argv)
          }
      }
  

--- a/recipes-extended/xen/files/libxl-misc-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-misc-xenmgr-support.patch
@@ -36,7 +36,7 @@ Index: xen-4.6.1/tools/libxl/libxl.c
 ===================================================================
 --- xen-4.6.1.orig/tools/libxl/libxl.c
 +++ xen-4.6.1/tools/libxl/libxl.c
-@@ -3481,6 +3481,8 @@ void libxl__device_nic_add(libxl__egc *e
+@@ -3479,6 +3479,8 @@ void libxl__device_nic_add(libxl__egc *e
      aodev->action = LIBXL__DEVICE_ACTION_ADD;
      libxl__wait_device_connection(egc, aodev);
  
@@ -45,7 +45,7 @@ Index: xen-4.6.1/tools/libxl/libxl.c
      rc = 0;
  out:
      libxl__xs_transaction_abort(gc, &t);
-@@ -4173,6 +4175,9 @@ int libxl__device_vfb_add(libxl__gc *gc,
+@@ -4171,6 +4173,9 @@ int libxl__device_vfb_add(libxl__gc *gc,
                                libxl__xs_kvs_of_flexarray(gc, back, back->count),
                                libxl__xs_kvs_of_flexarray(gc, front, front->count),
                                NULL);
@@ -55,7 +55,7 @@ Index: xen-4.6.1/tools/libxl/libxl.c
      rc = 0;
  out:
      return rc;
-@@ -6777,7 +6782,7 @@ int libxl_retrieve_domain_configuration(
+@@ -6775,7 +6780,7 @@ int libxl_retrieve_domain_configuration(
                      break;                                              \
              }                                                           \
                                                                          \
@@ -301,7 +301,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
          }
      }
  
-@@ -3014,8 +2994,6 @@ start:
+@@ -3018,8 +2998,6 @@ start:
                   */
                  dom_info->console_autoconnect = 0;
  
@@ -310,7 +310,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
                  if (common_domname
                      && strcmp(d_config.c_info.name, common_domname)) {
                      d_config.c_info.name = strdup(common_domname);
-@@ -3691,13 +3669,17 @@ static void unpause_domain(uint32_t domi
+@@ -3695,13 +3673,17 @@ static void unpause_domain(uint32_t domi
  static void destroy_domain(uint32_t domid, int force)
  {
      int rc;


### PR DESCRIPTION
- Fix 'shutdown' state change before domid is released
- When reboot/shutdown comes from inside guest, now change state
  to 'rebooting' or 'shutdowning' instead of going straight
  from 'running' to 'shutdown'

Signed-off-by: Chris Rogers rogersc@ainfosec.com
